### PR TITLE
Add Lambdas to Typed Expression Language

### DIFF
--- a/snarkl.cabal
+++ b/snarkl.cabal
@@ -47,6 +47,7 @@ library
     Snarkl.Errors
     Snarkl.Field
     Snarkl.Interp
+    Snarkl.Language
     Snarkl.Language.Expr
     Snarkl.Language.LambdaExpr
     Snarkl.Language.Syntax
@@ -101,8 +102,8 @@ test-suite spec
     Snarkl.Example.Stack
     Snarkl.Example.Tree
     Test.Snarkl.DataflowSpec
-    Test.Snarkl.Unit.Programs
     Test.Snarkl.LambdaSpec
+    Test.Snarkl.Unit.Programs
     Test.Snarkl.UnitSpec
     Test.UnionFindSpec
 

--- a/snarkl.cabal
+++ b/snarkl.cabal
@@ -48,6 +48,7 @@ library
     Snarkl.Field
     Snarkl.Interp
     Snarkl.Language.Expr
+    Snarkl.Language.LambdaExpr
     Snarkl.Language.Syntax
     Snarkl.Language.SyntaxMonad
     Snarkl.Language.TExpr

--- a/snarkl.cabal
+++ b/snarkl.cabal
@@ -102,6 +102,7 @@ test-suite spec
     Snarkl.Example.Tree
     Test.Snarkl.DataflowSpec
     Test.Snarkl.Unit.Programs
+    Test.Snarkl.LambdaSpec
     Test.Snarkl.UnitSpec
     Test.UnionFindSpec
 

--- a/src/Snarkl/Compile.hs
+++ b/src/Snarkl/Compile.hs
@@ -9,7 +9,6 @@ module Snarkl.Compile
     get_constraints,
     constraints_of_texp,
     r1cs_of_constraints,
-    expOfTExp,
   )
 where
 
@@ -39,17 +38,14 @@ import Snarkl.Constraint.Simplify (do_simplify)
 import Snarkl.Constraint.Solve (solve)
 import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
 import Snarkl.Field (Field (add, inv, neg, one, zero))
-import Snarkl.Language.Expr
+import Snarkl.Language
   ( Exp (..),
+    TExp,
     Variable (Variable),
-    do_const_prop,
-    var_of_exp,
-  )
-import Snarkl.Language.LambdaExpr (expOfLambdaExp)
-import Snarkl.Language.TExpr
-  ( TExp,
     booleanVarsOfTexp,
-    lambdaExpOfTExp,
+    do_const_prop,
+    expOfTExp,
+    var_of_exp,
   )
 
 ----------------------------------------------------------------
@@ -503,6 +499,3 @@ constraints_of_texp out in_vars te =
           num_constraint_vars
           in_vars
           [out]
-
-expOfTExp :: (Field a, Typeable ty) => TExp ty a -> Exp a
-expOfTExp = expOfLambdaExp . lambdaExpOfTExp

--- a/src/Snarkl/Compile.hs
+++ b/src/Snarkl/Compile.hs
@@ -45,10 +45,11 @@ import Snarkl.Language.Expr
     do_const_prop,
     var_of_exp,
   )
+import Snarkl.Language.LambdaExpr (expOfLambdaExp)
 import Snarkl.Language.TExpr
   ( TExp,
     booleanVarsOfTexp,
-    expOfTExp,
+    lambdaExpOfTExp,
   )
 
 ----------------------------------------------------------------
@@ -502,3 +503,6 @@ constraints_of_texp out in_vars te =
           num_constraint_vars
           in_vars
           [out]
+
+expOfTExp :: (Field a, Typeable ty) => TExp ty a -> Exp a
+expOfTExp = expOfLambdaExp . lambdaExpOfTExp

--- a/src/Snarkl/Constraint/Constraints.hs
+++ b/src/Snarkl/Constraint/Constraints.hs
@@ -17,12 +17,7 @@ where
 import Control.Monad.State (State)
 import qualified Data.IntMap.Lazy as Map
 import qualified Data.Set as Set
-import Snarkl.Backend.R1CS.Poly
-  ( Poly (Poly),
-    const_poly,
-    var_poly,
-  )
-import Snarkl.Backend.R1CS.R1CS (R1C (R1C), R1CS (R1CS))
+import Snarkl.Backend.R1CS (Poly (Poly), R1C (R1C), R1CS (R1CS), const_poly, var_poly)
 import Snarkl.Common (Assgn, Var)
 import Snarkl.Constraint.SimplMonad (SEnv)
 import Snarkl.Errors (ErrMsg (ErrMsg), failWith)

--- a/src/Snarkl/Constraint/Constraints.hs
+++ b/src/Snarkl/Constraint/Constraints.hs
@@ -17,7 +17,12 @@ where
 import Control.Monad.State (State)
 import qualified Data.IntMap.Lazy as Map
 import qualified Data.Set as Set
-import Snarkl.Backend.R1CS (Poly (Poly), R1C (R1C), R1CS (R1CS), const_poly, var_poly)
+import Snarkl.Backend.R1CS.Poly
+  ( Poly (Poly),
+    const_poly,
+    var_poly,
+  )
+import Snarkl.Backend.R1CS.R1CS (R1C (R1C), R1CS (R1CS))
 import Snarkl.Common (Assgn, Var)
 import Snarkl.Constraint.SimplMonad (SEnv)
 import Snarkl.Errors (ErrMsg (ErrMsg), failWith)

--- a/src/Snarkl/Constraint/SimplMonad.hs
+++ b/src/Snarkl/Constraint/SimplMonad.hs
@@ -16,9 +16,9 @@ where
 import Control.Monad.State
 import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
-import Snarkl.Common
+import Snarkl.Common (Assgn, Var)
 import qualified Snarkl.Constraint.UnionFind as UF
-import Snarkl.Field
+import Snarkl.Field (Field)
 
 ----------------------------------------------------------------
 --                  Simplifier State Monad                    --

--- a/src/Snarkl/Constraint/Simplify.hs
+++ b/src/Snarkl/Constraint/Simplify.hs
@@ -6,15 +6,31 @@ module Snarkl.Constraint.Simplify
   )
 where
 
-import Control.Monad.State
+import Control.Monad.State (State, runState)
 import Data.List (foldl')
 import qualified Data.Set as Set
-import Snarkl.Common
+import Snarkl.Common (Assgn, Var, intMapToMap)
 import Snarkl.Constraint.Constraints
+  ( CoeffList (CoeffList, asList),
+    Constraint (..),
+    ConstraintSet,
+    ConstraintSystem (cs_constraints, cs_in_vars, cs_out_vars),
+    cadd,
+    constraint_vars,
+  )
 import Snarkl.Constraint.SimplMonad
+  ( SEnv (SEnv),
+    SolveMode (JustSimplify, UseMagic),
+    assgn_of_vars,
+    bind_of_var,
+    bind_var,
+    root_of_var,
+    solve_mode_flag,
+    unite_vars,
+  )
 import qualified Snarkl.Constraint.UnionFind as UF
-import Snarkl.Errors
-import Snarkl.Field
+import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
+import Snarkl.Field (Field (..))
 
 ----------------------------------------------------------------
 --                         Substitution                       --

--- a/src/Snarkl/Constraint/Solve.hs
+++ b/src/Snarkl/Constraint/Solve.hs
@@ -7,11 +7,13 @@ import qualified Data.IntMap.Lazy as Map
 import Data.Maybe
   ( isJust,
   )
-import Snarkl.Common
+import Snarkl.Common (Assgn)
 import Snarkl.Constraint.Constraints
-import Snarkl.Constraint.Simplify
-import Snarkl.Errors
-import Snarkl.Field
+  ( ConstraintSystem (cs_in_vars, cs_num_vars, cs_out_vars),
+  )
+import Snarkl.Constraint.Simplify (do_simplify)
+import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
+import Snarkl.Field (Field)
 
 -- | Starting from an initial partial assignment [env], solve the
 -- constraints [cs] and return the resulting complete assignment.

--- a/src/Snarkl/Constraint/UnionFind.hs
+++ b/src/Snarkl/Constraint/UnionFind.hs
@@ -13,8 +13,8 @@ module Snarkl.Constraint.UnionFind
 where
 
 import qualified Data.Map as Map
-import Data.Maybe
-import Snarkl.Errors
+import Data.Maybe (fromMaybe)
+import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
 
 data UnionFind node a = UnionFind
   { ids :: Map.Map node node,

--- a/src/Snarkl/Interp.hs
+++ b/src/Snarkl/Interp.hs
@@ -10,11 +10,9 @@ import Data.Data (Typeable)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Snarkl.Common (Op (..), UnOp (ZEq))
-import Snarkl.Compile (expOfTExp)
 import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
 import Snarkl.Field (Field (..))
-import Snarkl.Language.Expr (Exp (..), Variable)
-import Snarkl.Language.TExpr (TExp)
+import Snarkl.Language (Exp (..), TExp, Variable, expOfTExp)
 
 type Env a = Map Variable (Maybe a)
 

--- a/src/Snarkl/Interp.hs
+++ b/src/Snarkl/Interp.hs
@@ -1,18 +1,20 @@
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# LANGUAGE LambdaCase #-}
 
-{-# HLINT ignore "Use camelCase" #-}
 module Snarkl.Interp
   ( interp,
   )
 where
 
-import Control.Monad
+import Control.Monad (ap, foldM)
+import Data.Data (Typeable)
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Snarkl.Common
-import Snarkl.Errors
-import Snarkl.Field
-import Snarkl.Language.TExpr
+import Snarkl.Common (Op (..), UnOp (ZEq))
+import Snarkl.Compile (expOfTExp)
+import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
+import Snarkl.Field (Field (..))
+import Snarkl.Language.Expr (Exp (..), Variable)
+import Snarkl.Language.TExpr (TExp)
 
 type Env a = Map Variable (Maybe a)
 
@@ -35,16 +37,16 @@ instance Applicative (InterpM a) where
   pure = return
   mf <*> ma = ap mf ma
 
-raise_err :: ErrMsg -> InterpM a b
-raise_err err =
+raiseErr :: ErrMsg -> InterpM a b
+raiseErr err =
   InterpM (\_ -> Left err)
 
-add_binds :: [(Variable, Maybe a)] -> InterpM a (Maybe b)
-add_binds binds =
+addBinds :: [(Variable, Maybe a)] -> InterpM a (Maybe b)
+addBinds binds =
   InterpM (\rho -> Right (Map.union (Map.fromList binds) rho, Nothing))
 
-lookup_var :: (Show a) => Variable -> InterpM a (Maybe a)
-lookup_var x =
+lookupVar :: (Show a) => Variable -> InterpM a (Maybe a)
+lookupVar x =
   InterpM
     ( \rho -> case Map.lookup x rho of
         Nothing ->
@@ -57,128 +59,106 @@ lookup_var x =
         Just v -> Right (rho, v)
     )
 
-field_of_bool :: (Field a) => Bool -> a
-field_of_bool b = if b then one else zero
+fieldOfBool :: (Field a) => Bool -> a
+fieldOfBool b = if b then one else zero
 
-case_of_field :: (Field a) => Maybe a -> (Maybe Bool -> InterpM a b) -> InterpM a b
-case_of_field Nothing f = f Nothing
-case_of_field (Just v) f =
-  if v == zero
-    then f $ Just False
-    else
-      if v == one
-        then f $ Just True
-        else raise_err $ ErrMsg $ "expected " ++ show v ++ " to be boolean"
+caseOfField :: (Field a) => Maybe a -> (Maybe Bool -> InterpM a b) -> InterpM a b
+caseOfField Nothing f = f Nothing
+caseOfField (Just v) f
+  | v == zero = f $ Just False
+  | v == one = f $ Just True
+  | otherwise = raiseErr $ ErrMsg $ "expected " ++ show v ++ " to be boolean"
 
-bool_of_field :: (Field a) => a -> InterpM a Bool
-bool_of_field v =
-  case_of_field
+boolOfField :: (Field a) => a -> InterpM a Bool
+boolOfField v =
+  caseOfField
     (Just v)
-    ( \mb -> case mb of
-        Nothing -> raise_err $ ErrMsg "internal error in bool_of_field"
+    ( \case
+        Nothing -> raiseErr $ ErrMsg "internal error in bool_of_field"
         Just b -> return b
     )
 
-interp_unop ::
-  (Field a) =>
-  TUnop ty1 ty2 ->
-  TExp ty1 a ->
-  InterpM a (Maybe a)
-interp_unop op e2 =
-  do
-    mv2 <- interp_texp e2
-    case mv2 of
-      Nothing -> return Nothing
-      Just v2 ->
-        case op of
-          TUnop ZEq -> return $ Just $ field_of_bool (v2 == zero)
-
-interp_binop ::
-  (Field a) =>
-  TOp ty1 ty2 ty3 ->
-  TExp ty1 a ->
-  TExp ty2 a ->
-  InterpM a (Maybe a)
-interp_binop op e1 e2 =
-  do
-    mv1 <- interp_texp e1
-    mv2 <- interp_texp e2
-    case (mv1, mv2) of
-      (Nothing, _) -> return Nothing
-      (_, Nothing) -> return Nothing
-      (Just v1, Just v2) ->
-        do
-          v <- interp_val_binop v1 v2
-          return $ Just v
-  where
-    interp_val_binop v1 v2 =
-      case op of
-        TOp Add -> return $ v1 `add` v2
-        TOp Sub -> return $ v1 `add` (neg v2)
-        TOp Mult -> return $ v1 `mult` v2
-        TOp Div ->
-          case inv v2 of
-            Nothing -> raise_err $ ErrMsg $ show v2 ++ " not invertible"
-            Just v2' -> return $ v1 `mult` v2'
-        TOp And -> interp_boolean_binop v1 v2
-        TOp Or -> interp_boolean_binop v1 v2
-        TOp XOr -> interp_boolean_binop v1 v2
-        TOp BEq -> interp_boolean_binop v1 v2
-        TOp Eq -> return $ field_of_bool $ v1 == v2
-
-    interp_boolean_binop v1 v2 =
-      do
-        b1 <- bool_of_field v1
-        b2 <- bool_of_field v2
-        let b = case op of
-              TOp And -> b1 && b2
-              TOp Or -> b1 || b2
-              TOp XOr -> (b1 && not b2) || (b2 && not b1)
-              TOp BEq -> b1 == b2
-              _ -> failWith $ ErrMsg "internal error in interp_binop"
-         in return $ field_of_bool b
-
-interp_val :: (Field a) => Val ty a -> InterpM a a
-interp_val v =
-  case v of
-    VField v' -> return v'
-    VTrue -> return $ field_of_bool True
-    VFalse -> return $ field_of_bool False
-    VUnit -> return one
-    VLoc _ -> raise_err $ ErrMsg "location in source program"
-
-interp_texp ::
-  ( Field a
+interpTExp ::
+  ( Field a,
+    Typeable ty
   ) =>
-  TExp ty1 a ->
+  TExp ty a ->
   InterpM a (Maybe a)
-interp_texp e =
-  case e of
-    TEVar (TVar x) -> lookup_var x
-    TEVal v -> interp_val v >>= return . Just
-    TEUnop op e2 -> interp_unop op e2
-    TEBinop op e1 e2 -> interp_binop op e1 e2
-    TEIf eb e1 e2 ->
-      do
-        mv <- interp_texp eb
-        case_of_field
-          mv
-          ( \mb -> case mb of
-              Nothing -> return Nothing
-              Just b -> if b then interp_texp e1 else interp_texp e2
-          )
-    TEAssert e1 e2 ->
-      case (e1, e2) of
-        (TEVar (TVar x), _) ->
-          do
-            v2 <- interp_texp e2
-            add_binds [(x, v2)]
-        (_, _) -> raise_err $ ErrMsg $ show e1 ++ " not a variable"
-    TESeq e1 e2 ->
-      do
-        _ <- interp_texp e1
-        interp_texp e2
-    TEBot -> return Nothing
+interpTExp e = do
+  let _exp = expOfTExp e
+  interpExpr _exp
 
-interp :: (Field a) => Map Variable a -> TExp ty a -> Either ErrMsg (Env a, Maybe a)
-interp rho e = runInterpM (interp_texp e) $ Map.map Just rho
+interp ::
+  (Field a, Typeable ty) =>
+  Map Variable a ->
+  TExp ty a ->
+  Either ErrMsg (Env a, Maybe a)
+interp rho e = runInterpM (interpTExp e) $ Map.map Just rho
+
+interpExpr ::
+  (Field a) =>
+  Exp a ->
+  InterpM a (Maybe a)
+interpExpr e = case e of
+  EVar x -> lookupVar x
+  EVal v -> pure $ Just v
+  EUnop op e2 -> do
+    v2 <- interpExpr e2
+    case v2 of
+      Nothing -> pure Nothing
+      Just v2' -> case op of
+        ZEq -> return $ Just $ fieldOfBool (v2' == zero)
+  EBinop op _es -> case _es of
+    [] -> failWith $ ErrMsg "empty binary args"
+    (a : as) -> do
+      b <- interpExpr a
+      foldM (interp_binop_expr op) b as
+  EIf eb e1 e2 ->
+    do
+      mb <- interpExpr eb
+      case mb of
+        Nothing -> pure Nothing
+        Just _b -> boolOfField _b >>= \b -> if b then interpExpr e1 else interpExpr e2
+  EAssert e1 e2 ->
+    case (e1, e2) of
+      (EVar x, _) ->
+        do
+          v2 <- interpExpr e2
+          addBinds [(x, v2)]
+      (_, _) -> raiseErr $ ErrMsg $ show e1 ++ " not a variable"
+  ESeq es -> last <$> mapM interpExpr es
+  EUnit -> return $ Just one
+  where
+    interp_binop_expr :: (Field a) => Op -> Maybe a -> Exp a -> InterpM a (Maybe a)
+    interp_binop_expr _ Nothing _ = return Nothing
+    interp_binop_expr _op (Just a1) _exp = do
+      ma2 <- interpExpr _exp
+      case ma2 of
+        Nothing -> return Nothing
+        Just a2 -> Just <$> op a1 a2
+      where
+        op :: (Field a) => a -> a -> InterpM a a
+        op a b = case _op of
+          Add -> pure $ a `add` b
+          Sub -> pure $ a `add` neg b
+          Mult -> pure $ a `mult` b
+          Div -> pure $
+            case inv b of
+              Nothing -> failWith $ ErrMsg $ show b ++ " not invertible"
+              Just b' -> a `mult` b'
+          And -> interpBooleanBinop a b
+          Or -> interpBooleanBinop a b
+          XOr -> interpBooleanBinop a b
+          BEq -> interpBooleanBinop a b
+          Eq -> pure $ fieldOfBool $ a == b
+        interpBooleanBinop :: (Field a) => a -> a -> InterpM a a
+        interpBooleanBinop a b =
+          do
+            b1 <- boolOfField a
+            b2 <- boolOfField b
+            case _op of
+              And -> return $ fieldOfBool $ b1 && b2
+              Or -> return $ fieldOfBool $ b1 || b2
+              XOr -> return $ fieldOfBool $ (b1 && not b2) || (b2 && not b1)
+              BEq -> return $ fieldOfBool $ b1 == b2
+              _ -> failWith $ ErrMsg "internal error in interp_binop"

--- a/src/Snarkl/Interp.hs
+++ b/src/Snarkl/Interp.hs
@@ -112,7 +112,7 @@ interpExpr e = case e of
     [] -> failWith $ ErrMsg "empty binary args"
     (a : as) -> do
       b <- interpExpr a
-      foldM (interp_binop_expr op) b as
+      foldM (interpBinopExpr op) b as
   EIf eb e1 e2 ->
     do
       mb <- interpExpr eb
@@ -129,9 +129,9 @@ interpExpr e = case e of
   ESeq es -> last <$> mapM interpExpr es
   EUnit -> return $ Just one
   where
-    interp_binop_expr :: (Field a) => Op -> Maybe a -> Exp a -> InterpM a (Maybe a)
-    interp_binop_expr _ Nothing _ = return Nothing
-    interp_binop_expr _op (Just a1) _exp = do
+    interpBinopExpr :: (Field a) => Op -> Maybe a -> Exp a -> InterpM a (Maybe a)
+    interpBinopExpr _ Nothing _ = return Nothing
+    interpBinopExpr _op (Just a1) _exp = do
       ma2 <- interpExpr _exp
       case ma2 of
         Nothing -> return Nothing

--- a/src/Snarkl/Interp.hs
+++ b/src/Snarkl/Interp.hs
@@ -124,7 +124,9 @@ interpExpr e = case e of
           v2 <- interpExpr e2
           addBinds [(x, v2)]
       (_, _) -> raiseErr $ ErrMsg $ show e1 ++ " not a variable"
-  ESeq es -> last <$> mapM interpExpr es
+  ESeq es -> case es of
+    [] -> failWith $ ErrMsg "empty sequence"
+    _ -> last <$> mapM interpExpr es
   EUnit -> return $ Just one
   where
     interpBinopExpr :: (Field a) => Op -> Maybe a -> Exp a -> InterpM a (Maybe a)

--- a/src/Snarkl/Language.hs
+++ b/src/Snarkl/Language.hs
@@ -1,0 +1,19 @@
+module Snarkl.Language
+  ( expOfTExp,
+    module Snarkl.Language.TExpr,
+    module Snarkl.Language.Expr,
+    module Snarkl.Language.SyntaxMonad,
+    module Snarkl.Language.Syntax,
+  )
+where
+
+import Data.Data (Typeable)
+import Snarkl.Field (Field)
+import Snarkl.Language.Expr
+import Snarkl.Language.LambdaExpr (expOfLambdaExp)
+import Snarkl.Language.Syntax
+import Snarkl.Language.SyntaxMonad
+import Snarkl.Language.TExpr
+
+expOfTExp :: (Field a, Typeable ty) => TExp ty a -> Exp a
+expOfTExp = expOfLambdaExp . lambdaExpOfTExp

--- a/src/Snarkl/Language/Expr.hs
+++ b/src/Snarkl/Language/Expr.hs
@@ -9,14 +9,20 @@ module Snarkl.Language.Expr
   )
 where
 
-import Control.Monad.State
+import Control.Monad.State (State, gets, modify, runState)
 import Data.Kind (Type)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Prettyprinter
-import Snarkl.Common
-import Snarkl.Errors
-import Snarkl.Field
+  ( Pretty (pretty),
+    hsep,
+    parens,
+    punctuate,
+    (<+>),
+  )
+import Snarkl.Common (Op, UnOp, isAssoc)
+import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
+import Snarkl.Field (Field)
 
 newtype Variable = Variable Int deriving (Eq, Ord, Show, Pretty)
 

--- a/src/Snarkl/Language/LambdaExpr.hs
+++ b/src/Snarkl/Language/LambdaExpr.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Snarkl.Language.LambdaExpr
+  ( Exp (..),
+    expOfLambdaExp,
+    expBinop,
+    expSeq,
+  )
+where
+
+import Control.Monad.Error.Class (throwError)
+import Control.Monad.State (State, gets, modify, runState)
+import Data.Kind (Type)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Snarkl.Common (Op, UnOp, isAssoc)
+import Snarkl.Field (Field)
+import Snarkl.Language.Expr (Variable)
+import qualified Snarkl.Language.Expr as Core
+
+data Exp :: Type -> Type where
+  EVar :: Variable -> Exp a
+  EVal :: (Field a) => a -> Exp a
+  EUnop :: UnOp -> Exp a -> Exp a
+  EBinop :: Op -> [Exp a] -> Exp a
+  EIf :: Exp a -> Exp a -> Exp a -> Exp a
+  EAssert :: Exp a -> Exp a -> Exp a
+  ESeq :: Exp a -> Exp a -> Exp a
+  EUnit :: Exp a
+  EAbs :: Variable -> Exp a -> Exp a
+  EApp :: Exp a -> Exp a -> Exp a
+
+deriving instance (Show a) => Show (Exp a)
+
+deriving instance (Eq a) => Eq (Exp a)
+
+type Env a = Map Variable (Exp a)
+
+defaultEnv :: Env a
+defaultEnv = Map.empty
+
+applyLambdas ::
+  Exp a ->
+  (Exp a, Env a)
+applyLambdas expression = runState (go expression) defaultEnv
+  where
+    go :: Exp a -> State (Env a) (Exp a)
+    go = \case
+      EVar var -> do
+        ma <- gets (Map.lookup var)
+        case ma of
+          Nothing -> do
+            pure (EVar var)
+          Just e -> go e
+      e@(EVal _) -> pure e
+      EUnit -> pure EUnit
+      EUnop op e -> EUnop op <$> go e
+      EBinop op es -> EBinop op <$> mapM go es
+      EIf b e1 e2 -> EIf <$> go b <*> go e1 <*> go e2
+      EAssert (EVar v1) e@(EAbs _ _) -> do
+        _e <- go e
+        modify $ Map.insert v1 _e
+        pure EUnit
+      EAssert e1 e2 -> EAssert <$> go e1 <*> go e2
+      ESeq e1 e2 -> ESeq <$> go e1 <*> go e2
+      EAbs var e -> do
+        EAbs var <$> go e
+      EApp (EAbs var e1) e2 -> do
+        _e2 <- go e2
+        modify $ Map.insert var e2
+        go (substitute var e2 e1)
+      EApp e1 e2 -> do
+        _e1 <- go e1
+        _e2 <- go e2
+        go (EApp _e1 _e2)
+
+substitute :: Variable -> Exp a -> Exp a -> Exp a
+substitute var e1 = \case
+  e@(EVar var') -> if var == var' then e1 else e
+  e@(EVal _) -> e
+  EUnit -> EUnit
+  EUnop op e -> EUnop op (substitute var e1 e)
+  EBinop op es -> EBinop op (map (substitute var e1) es)
+  EIf b e2 e3 -> EIf (substitute var e1 b) (substitute var e1 e2) (substitute var e1 e3)
+  EAssert e2 e3 -> EAssert (substitute var e1 e2) (substitute var e1 e3)
+  ESeq e2 e3 -> ESeq (substitute var e1 e2) (substitute var e1 e3)
+  EAbs var' e -> EAbs var' (substitute var e1 e)
+  EApp e2 e3 -> EApp (substitute var e1 e2) (substitute var e1 e3)
+
+expBinop :: Op -> Exp a -> Exp a -> Exp a
+expBinop op e1 e2 =
+  case (e1, e2) of
+    (EBinop op1 l1, EBinop op2 l2)
+      | op1 == op2 && op2 == op && isAssoc op ->
+          EBinop op (l1 ++ l2)
+    (EBinop op1 l1, _)
+      | op1 == op && isAssoc op ->
+          EBinop op (l1 ++ [e2])
+    (_, EBinop op2 l2)
+      | op2 == op && isAssoc op ->
+          EBinop op (e1 : l2)
+    (_, _) -> EBinop op [e1, e2]
+
+-- | Smart constructor for sequence, ensuring all expressions are
+--  flattened to top level.
+expSeq :: Core.Exp a -> Core.Exp a -> Core.Exp a
+expSeq e1 e2 =
+  case (e1, e2) of
+    (Core.ESeq l1, Core.ESeq l2) -> Core.ESeq (l1 ++ l2)
+    (Core.ESeq l1, _) -> Core.ESeq (l1 ++ [e2])
+    (_, Core.ESeq l2) -> Core.ESeq (e1 : l2)
+    (_, _) -> Core.ESeq [e1, e2]
+
+expOfLambdaExp :: (Show a) => Exp a -> Core.Exp a
+expOfLambdaExp _exp =
+  let (coreExp, _) = applyLambdas _exp
+   in case expOfLambdaExp' coreExp of
+        Left err -> error err
+        Right e -> e
+  where
+    expOfLambdaExp' :: (Show a) => Exp a -> Either String (Core.Exp a)
+    expOfLambdaExp' = \case
+      EVar var -> pure $ Core.EVar var
+      EVal v -> pure $ Core.EVal v
+      EUnit -> pure Core.EUnit
+      EUnop op e -> Core.EUnop op <$> expOfLambdaExp' e
+      EBinop op es -> Core.EBinop op <$> mapM expOfLambdaExp' es
+      EIf b e1 e2 -> Core.EIf <$> expOfLambdaExp' b <*> expOfLambdaExp' e1 <*> expOfLambdaExp' e2
+      EAssert e1 e2 -> Core.EAssert <$> expOfLambdaExp' e1 <*> expOfLambdaExp' e2
+      ESeq e1 e2 -> expSeq <$> expOfLambdaExp' e1 <*> expOfLambdaExp' e2
+      e -> throwError ("Impossible after IR simplicifaction: " <> show e)

--- a/src/Snarkl/Language/LambdaExpr.hs
+++ b/src/Snarkl/Language/LambdaExpr.hs
@@ -4,7 +4,6 @@ module Snarkl.Language.LambdaExpr
   ( Exp (..),
     expOfLambdaExp,
     expBinop,
-    expSeq,
   )
 where
 

--- a/src/Snarkl/Language/Syntax.hs
+++ b/src/Snarkl/Language/Syntax.hs
@@ -58,6 +58,7 @@ module Snarkl.Language.Syntax
     lambda,
     curry,
     uncurry,
+    apply,
   )
 where
 
@@ -722,3 +723,6 @@ uncurry f p = do
   y <- snd_pair p
   g <- f x
   return $ TEApp g y
+
+apply :: (Typeable a, Typeable b) => TExp ('TFun a b) Rational -> TExp a Rational -> Comp b
+apply f x = return $ TEApp f x

--- a/src/Snarkl/Language/Syntax.hs
+++ b/src/Snarkl/Language/Syntax.hs
@@ -63,12 +63,48 @@ module Snarkl.Language.Syntax
 where
 
 import Data.String (IsString (..))
-import Data.Typeable
+import Data.Typeable (Typeable)
 import Snarkl.Common
-import Snarkl.Errors
+  ( Op (Add, And, BEq, Div, Eq, Mult, Sub, XOr),
+    UnOp (ZEq),
+  )
+import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
 import Snarkl.Language.SyntaxMonad
+  ( Comp,
+    Env,
+    State (..),
+    arr,
+    assert_bot,
+    assert_false,
+    assert_true,
+    false,
+    fresh_var,
+    fst_pair,
+    get,
+    guard,
+    input_arr,
+    is_bot,
+    is_false,
+    is_true,
+    pair,
+    raise_err,
+    return,
+    runState,
+    set,
+    snd_pair,
+    true,
+    unit,
+    (>>=),
+  )
 import Snarkl.Language.TExpr
-import Unsafe.Coerce
+  ( Rep,
+    TExp (TEAbs, TEApp, TEBinop, TEBot, TEIf, TEUnop, TEVal, TEVar),
+    TOp (TOp),
+    TUnop (TUnop),
+    Ty (TArr, TBool, TField, TFun, TMu, TProd, TSum, TUnit),
+    Val (VFalse, VField, VTrue, VUnit),
+  )
+import Unsafe.Coerce (unsafeCoerce)
 import Prelude hiding
   ( curry,
     fromRational,

--- a/src/Snarkl/Language/SyntaxMonad.hs
+++ b/src/Snarkl/Language/SyntaxMonad.hs
@@ -54,9 +54,21 @@ import Control.Monad.Supply (Supply, runSupply)
 import Control.Monad.Supply.Class (MonadSupply (fresh))
 import qualified Data.Map.Strict as Map
 import Data.String (IsString (..))
-import Data.Typeable
-import Snarkl.Errors
+import Data.Typeable (Typeable)
+import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
+import Snarkl.Language.Expr (Variable (..))
 import Snarkl.Language.TExpr
+  ( Loc,
+    TExp (TEAssert, TEBinop, TEBot, TESeq, TEUnop, TEVal, TEVar),
+    TLoc (TLoc),
+    TVar (TVar),
+    Ty (TArr, TBool, TProd, TUnit),
+    Val (VFalse, VLoc, VTrue, VUnit),
+    lastSeq,
+    locOfTexp,
+    teSeq,
+    varOfTExp,
+  )
 import Prelude hiding
   ( fromRational,
     negate,

--- a/src/Snarkl/Language/TExpr.hs
+++ b/src/Snarkl/Language/TExpr.hs
@@ -32,12 +32,6 @@ import Snarkl.Field (Field (one, zero))
 import qualified Snarkl.Language.Expr as Core
 import qualified Snarkl.Language.LambdaExpr as LE
 
---  ( Exp (EAssert, EIf, EUnit, EUnop, EVal, EVar),
---    Variable (..),
---    exp_binop,
---    exp_seq,
---  )
-
 data TFunct where
   TFConst :: Ty -> TFunct
   TFId :: TFunct

--- a/src/Snarkl/Language/TExpr.hs
+++ b/src/Snarkl/Language/TExpr.hs
@@ -12,7 +12,6 @@ module Snarkl.Language.TExpr
     TVar (..),
     Loc,
     TLoc (..),
-    Core.Variable (..),
     booleanVarsOfTexp,
     lambdaExpOfTExp,
     varOfTExp,
@@ -29,7 +28,7 @@ import Prettyprinter (Pretty (pretty), line, parens, (<+>))
 import Snarkl.Common (Op, UnOp)
 import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
 import Snarkl.Field (Field (one, zero))
-import qualified Snarkl.Language.Expr as Core
+import Snarkl.Language.Expr (Variable)
 import qualified Snarkl.Language.LambdaExpr as LE
 
 data TFunct where
@@ -98,7 +97,7 @@ type instance Rep ('TFSum f g) x = 'TSum (Rep f x) (Rep g x)
 
 type instance Rep ('TFComp f g) x = Rep f (Rep g x)
 
-newtype TVar (ty :: Ty) = TVar Core.Variable deriving (Eq, Show)
+newtype TVar (ty :: Ty) = TVar Variable deriving (Eq, Show)
 
 instance Pretty (TVar ty) where
   pretty (TVar x) = "var_" <> pretty x
@@ -229,10 +228,10 @@ teSeq te1 te2 = case (te1, te2) of
   (TESeq tx ty, _) -> teSeq tx (teSeq ty te2)
   (_, _) -> te2
 
-booleanVarsOfTexp :: (Typeable ty) => TExp ty a -> [Core.Variable]
+booleanVarsOfTexp :: (Typeable ty) => TExp ty a -> [Variable]
 booleanVarsOfTexp = go []
   where
-    go :: (Typeable ty) => [Core.Variable] -> TExp ty a -> [Core.Variable]
+    go :: (Typeable ty) => [Variable] -> TExp ty a -> [Variable]
     go vars (TEVar t@(TVar x)) =
       if varIsBoolean t
         then x : vars
@@ -248,7 +247,7 @@ booleanVarsOfTexp = go []
     go vars (TEAbs _ e) = go vars e
     go vars (TEApp e1 e2) = go (go vars e1) e2
 
-varOfTExp :: (Show (TExp ty a)) => TExp ty a -> Core.Variable
+varOfTExp :: (Show (TExp ty a)) => TExp ty a -> Variable
 varOfTExp te = case lastSeq te of
   TEVar (TVar x) -> x
   _ -> failWith $ ErrMsg ("varOfTExp: expected var: " ++ show te)

--- a/src/Snarkl/Toplevel.hs
+++ b/src/Snarkl/Toplevel.hs
@@ -48,7 +48,7 @@ module Snarkl.Toplevel
     benchmark_comp,
 
     -- * Re-exported modules
-    module Snarkl.Language.SyntaxMonad,
+    module Snarkl.Language,
     module Snarkl.Constraint.Constraints,
     module Snarkl.Constraint.Simplify,
     module Snarkl.Backend.R1CS,
@@ -58,18 +58,21 @@ where
 import qualified Data.IntMap.Lazy as IntMap
 import Data.List (sort)
 import qualified Data.Map.Strict as Map
-import Data.Typeable
-import Prettyprinter
+import Data.Typeable (Typeable)
+import Prettyprinter (Pretty (pretty))
 import Snarkl.Backend.R1CS
 import Snarkl.Compile
+  ( SimplParam,
+    constraints_of_texp,
+    r1cs_of_constraints,
+  )
 import Snarkl.Constraint.Constraints
 import Snarkl.Constraint.Simplify
-import Snarkl.Errors
-import Snarkl.Field
+import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
+import Snarkl.Field (Field)
 import Snarkl.Interp (interp)
-import Snarkl.Language.SyntaxMonad
-import Snarkl.Language.TExpr
-import System.Exit
+import Snarkl.Language
+import System.Exit (ExitCode (..))
 import System.IO
   ( IOMode (WriteMode),
     hFlush,
@@ -79,6 +82,11 @@ import System.IO
     withFile,
   )
 import System.Process
+  ( CreateProcess (cwd),
+    createProcess,
+    proc,
+    waitForProcess,
+  )
 import Prelude
 import qualified Prelude as P
 

--- a/src/Snarkl/Toplevel.hs
+++ b/src/Snarkl/Toplevel.hs
@@ -91,6 +91,7 @@ import qualified Prelude as P
 -- | Using the executable semantics for the 'TExp' language, execute
 -- the computation on the provided inputs, returning the 'Rational' result.
 comp_interp ::
+  (Typeable ty) =>
   Comp ty ->
   [Rational] ->
   Rational

--- a/tests/Test/Snarkl/LambdaSpec.hs
+++ b/tests/Test/Snarkl/LambdaSpec.hs
@@ -8,8 +8,16 @@ import qualified Data.Map as Map
 import Snarkl.Field
 import Snarkl.Interp (interp)
 import Snarkl.Language.Syntax
+  ( apply,
+    curry,
+    lambda,
+    pair,
+    uncurry,
+    (*),
+    (+),
+  )
 import qualified Snarkl.Language.SyntaxMonad as SM
-import Snarkl.Language.TExpr (TExp, Ty (..), Variable (Variable))
+import Snarkl.Language.TExpr (TExp, Ty (TField, TFun, TProd))
 import Snarkl.Toplevel (comp_interp)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.QuickCheck (Testable (property))

--- a/tests/Test/Snarkl/LambdaSpec.hs
+++ b/tests/Test/Snarkl/LambdaSpec.hs
@@ -1,0 +1,58 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Redundant curry" #-}
+{-# HLINT ignore "Redundant uncurry" #-}
+module Test.Snarkl.LambdaSpec where
+
+import qualified Data.Map as Map
+import Snarkl.Field
+import Snarkl.Interp (interp)
+import Snarkl.Language.Syntax
+import qualified Snarkl.Language.SyntaxMonad as SM
+import Snarkl.Language.TExpr (TExp, Ty (..), Variable (Variable))
+import Snarkl.Toplevel (comp_interp)
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.QuickCheck (Testable (property))
+import Prelude hiding (apply, curry, return, uncurry, (*), (+))
+
+spec :: Spec
+spec = do
+  describe "Snarkl.Lambda" $ do
+    describe "curry/uncurry identities for simply operations" $ do
+      it "curry . uncurry == id" $ do
+        let f :: TExp 'TField Rational -> SM.Comp ('TFun 'TField 'TField)
+            f x = lambda $ \y -> SM.return (x + y)
+            g :: TExp 'TField Rational -> SM.Comp ('TFun 'TField 'TField)
+            g = curry (uncurry f)
+            prog1 =
+              SM.fresh_input SM.>>= \a ->
+                SM.fresh_input SM.>>= \b ->
+                  f a SM.>>= \k ->
+                    apply k b
+            prog2 =
+              SM.fresh_input SM.>>= \a ->
+                SM.fresh_input SM.>>= \b ->
+                  g a SM.>>= \k ->
+                    apply k b
+        property $ \a b -> comp_interp prog1 [a, b] == comp_interp prog2 [a, b]
+
+      it "uncurry . curry == id" $ do
+        let f :: TExp ('TProd 'TField 'TField) Rational -> SM.Comp 'TField
+            f p =
+              SM.fst_pair p SM.>>= \x ->
+                SM.snd_pair p SM.>>= \y ->
+                  SM.return (x * y)
+            g :: TExp ('TProd 'TField 'TField) Rational -> SM.Comp 'TField
+            g = uncurry (curry f)
+
+            prog1 =
+              SM.fresh_input SM.>>= \a ->
+                SM.fresh_input SM.>>= \b ->
+                  pair a b SM.>>= \p ->
+                    f p
+            prog2 =
+              SM.fresh_input SM.>>= \a ->
+                SM.fresh_input SM.>>= \b ->
+                  pair a b SM.>>= \p ->
+                    g p
+        property $ \a b -> comp_interp prog1 [a, b] == comp_interp prog2 [a, b]

--- a/tests/Test/Snarkl/UnitSpec.hs
+++ b/tests/Test/Snarkl/UnitSpec.hs
@@ -8,8 +8,8 @@ import Snarkl.Example.Lam
 import Snarkl.Example.List
 import Snarkl.Example.Peano
 import Snarkl.Example.Tree
-import Snarkl.Language.TExpr
-import Snarkl.Toplevel
+import Snarkl.Language.Syntax hiding (negate)
+import Snarkl.Toplevel (test_comp)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
 import Test.Snarkl.Unit.Programs
 import Prelude


### PR DESCRIPTION
- add Lambdas to `TExp`
- add an intermediate `LambdaExp` which implements lambda lifting before targeting `Exp`
- add basic tests for curry/uncurry
- module shifting around (i.e. package `Language` modules)