### PR TITLE
newtype Var

### DIFF
--- a/benchmarks/Harness.hs
+++ b/benchmarks/Harness.hs
@@ -3,7 +3,7 @@
 module Harness where
 
 import Data.Field.Galois (GaloisField, Prime, PrimeField)
-import qualified Data.IntMap.Lazy as IntMap
+import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Typeable
 import GHC.IO.Exception
@@ -50,7 +50,7 @@ test_simplify :: (Typeable ty, GaloisField k) => Comp ty k -> IO ()
 test_simplify mf =
   let texp_pkg = texp_of_comp mf
       constrs = constrs_of_texp texp_pkg
-      (_, constrs') = do_simplify False IntMap.empty constrs
+      (_, constrs') = do_simplify False Map.empty constrs
    in hPutStrLn stderr $
         show $
           Set.size $

--- a/snarkl.cabal
+++ b/snarkl.cabal
@@ -80,6 +80,7 @@ library
     , criterion      >=1.0
     , galois-field   >=1.0.4
     , hspec          >=2.0
+    , lens
     , mtl            >=2.2   && <2.3
     , parallel       >=3.2   && <3.3
     , prettyprinter

--- a/src/Snarkl/Backend/R1CS/Poly.hs
+++ b/src/Snarkl/Backend/R1CS/Poly.hs
@@ -1,7 +1,7 @@
 module Snarkl.Backend.R1CS.Poly where
 
 import Data.Field.Galois (GaloisField)
-import qualified Data.IntMap.Lazy as Map
+import qualified Data.Map as Map
 import Snarkl.Common
 
 data Poly a where
@@ -12,7 +12,7 @@ instance (Show a) => Show (Poly a) where
 
 -- | The constant polynomial equal 'c'
 const_poly :: (GaloisField a) => a -> Poly a
-const_poly c = Poly $ Map.insert (-1) c Map.empty
+const_poly c = Poly $ Map.insert (Var (-1)) c Map.empty
 
 -- | The polynomial equal variable 'x'
 var_poly ::

--- a/src/Snarkl/Backend/R1CS/R1CS.hs
+++ b/src/Snarkl/Backend/R1CS/R1CS.hs
@@ -8,7 +8,7 @@ where
 
 import Control.Parallel.Strategies
 import Data.Field.Galois (GaloisField)
-import qualified Data.IntMap.Lazy as Map
+import qualified Data.Map as Map
 import Snarkl.Backend.R1CS.Poly
 import Snarkl.Common
 import Snarkl.Errors
@@ -45,7 +45,7 @@ sat_r1c w c
   where
     inner :: (GaloisField a) => Poly a -> Assgn a -> a
     inner (Poly v) w' =
-      let c0 = Map.findWithDefault 0 (-1) v
+      let c0 = Map.findWithDefault 0 (Var (-1)) v
        in Map.foldlWithKey (f w') c0 v
 
     f w' acc v_key v_val =

--- a/src/Snarkl/Backend/R1CS/Serialize.hs
+++ b/src/Snarkl/Backend/R1CS/Serialize.hs
@@ -1,14 +1,14 @@
 module Snarkl.Backend.R1CS.Serialize (serialize_r1cs, serialize_assgn) where
 
 import Data.Field.Galois (PrimeField, fromP)
-import qualified Data.IntMap.Lazy as Map
+import qualified Data.Map as Map
 import Snarkl.Backend.R1CS.Poly
 import Snarkl.Backend.R1CS.R1CS
 import Snarkl.Common
 
 serialize_assgn :: (PrimeField k) => Assgn k -> String
 serialize_assgn m =
-  let binds = Map.toAscList $ Map.mapKeys (+ 1) m
+  let binds = Map.toAscList $ Map.mapKeys incVar m
    in concat $
         map (\(_, v) -> show (fromP v) ++ "\n") binds
 
@@ -16,10 +16,10 @@ serialize_poly :: (PrimeField k) => Poly k -> String
 serialize_poly p = case p of
   Poly m ->
     let size = Map.size m
-        binds = Map.toList $ Map.mapKeys (+ 1) m
+        binds = Map.toList $ Map.mapKeys incVar m
         string_binds =
           map
-            ( \(k, v) ->
+            ( \(Var k, v) ->
                 show k
                   ++ "\n"
                   ++ show (fromP v)

--- a/src/Snarkl/Common.hs
+++ b/src/Snarkl/Common.hs
@@ -2,13 +2,15 @@
 
 module Snarkl.Common where
 
-import qualified Data.IntMap.Lazy as IntMap
 import qualified Data.Map as Map
 import Prettyprinter
 
-type Var = Int
+newtype Var = Var Int deriving (Eq, Ord, Show)
 
-type Assgn a = IntMap.IntMap a
+incVar :: Var -> Var
+incVar (Var i) = Var (i + 1)
+
+type Assgn a = Map.Map Var a
 
 data UnOp = ZEq
   deriving (Eq, Show)
@@ -62,6 +64,3 @@ isAssoc op = case op of
   XOr -> True
   Eq -> True
   BEq -> True
-
-intMapToMap :: IntMap.IntMap v -> Map.Map Int v
-intMapToMap = Map.fromList . IntMap.toList

--- a/src/Snarkl/Constraint/Constraints.hs
+++ b/src/Snarkl/Constraint/Constraints.hs
@@ -16,10 +16,10 @@ where
 
 import Control.Monad.State (State)
 import Data.Field.Galois (GaloisField, Prime)
-import qualified Data.IntMap.Lazy as Map
+import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Snarkl.Backend.R1CS (Poly (Poly), R1C (R1C), R1CS (R1CS), const_poly, var_poly)
-import Snarkl.Common (Assgn, Var)
+import Snarkl.Common (Assgn, Var (Var))
 import Snarkl.Constraint.SimplMonad (SEnv)
 import Snarkl.Errors (ErrMsg (ErrMsg), failWith)
 
@@ -183,7 +183,7 @@ r1cs_of_cs cs =
     go (CAdd a m : cs') =
       R1C
         ( const_poly 1,
-          Poly $ Map.insert (-1) a $ Map.fromList (asList m),
+          Poly $ Map.insert (Var (-1)) a $ Map.fromList (asList m),
           const_poly 0
         )
         : go cs'
@@ -224,7 +224,7 @@ renumber_constraints cs =
 
     var_map =
       Map.fromList $
-        zip (cs_in_vars cs ++ filter isnt_input all_vars) [0 ..]
+        zip (cs_in_vars cs ++ filter isnt_input all_vars) (Var <$> [0 ..])
       where
         isnt_input = not . flip Set.member in_vars_set
         in_vars_set = Set.fromList $ cs_in_vars cs

--- a/src/Snarkl/Constraint/SimplMonad.hs
+++ b/src/Snarkl/Constraint/SimplMonad.hs
@@ -15,7 +15,6 @@ where
 
 import Control.Monad.State
 import Data.Field.Galois (GaloisField)
-import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
 import Snarkl.Common (Assgn, Var)
 import qualified Snarkl.Constraint.UnionFind as UF
@@ -80,7 +79,7 @@ assgn_of_vars vars =
   do
     binds <- mapM bind_of_var vars
     return
-      $ IntMap.fromList
+      $ Map.fromList
       $ concatMap
         ( \(x, ec) -> case ec of
             Left _ -> []

--- a/src/Snarkl/Constraint/Simplify.hs
+++ b/src/Snarkl/Constraint/Simplify.hs
@@ -10,7 +10,7 @@ import Control.Monad.State (State, runState, when)
 import Data.Field.Galois (GaloisField)
 import Data.List (foldl')
 import qualified Data.Set as Set
-import Snarkl.Common (Assgn, Var, intMapToMap)
+import Snarkl.Common (Assgn, Var)
 import Snarkl.Constraint.Constraints
   ( CoeffList (CoeffList, asList),
     Constraint (..),
@@ -194,7 +194,7 @@ do_simplify in_solve_mode env cs =
   -- Pinned vars are never optimized away.
   let pinned_vars = cs_in_vars cs ++ cs_out_vars cs ++ magic_vars (cs_constraints cs)
       do_solve = if in_solve_mode then UseMagic else JustSimplify
-      new_state = SEnv (UF.empty {UF.extras = intMapToMap env}) do_solve
+      new_state = SEnv (UF.empty {UF.extras = env}) do_solve
    in fst $ runState (go pinned_vars) new_state
   where
     go pinned_vars =

--- a/src/Snarkl/Constraint/Solve.hs
+++ b/src/Snarkl/Constraint/Solve.hs
@@ -4,11 +4,11 @@ module Snarkl.Constraint.Solve
 where
 
 import Data.Field.Galois (GaloisField)
-import qualified Data.IntMap.Lazy as Map
+import qualified Data.Map as Map
 import Data.Maybe
   ( isJust,
   )
-import Snarkl.Common (Assgn)
+import Snarkl.Common (Assgn, Var (..))
 import Snarkl.Constraint.Constraints
   ( ConstraintSystem (cs_in_vars, cs_num_vars, cs_out_vars),
   )
@@ -30,7 +30,7 @@ solve ::
   Assgn a
 solve cs env =
   let pinned_vars = cs_in_vars cs ++ cs_out_vars cs
-      all_vars = [0 .. cs_num_vars cs - 1]
+      all_vars = Var <$> [0 .. cs_num_vars cs - 1]
       (assgn, cs') = do_simplify True env cs
    in if all_assigned all_vars assgn
         then assgn

--- a/src/Snarkl/Constraint/Solve.hs
+++ b/src/Snarkl/Constraint/Solve.hs
@@ -30,6 +30,9 @@ solve ::
   Assgn a
 solve cs env =
   let pinned_vars = cs_in_vars cs ++ cs_out_vars cs
+      -- NOTE: This looks really bad, but actually the only time that solve is called
+      -- is right after renumber_constraints, which ensures that the variables are
+      -- numbered from 0 to n-1, where n is the number of variables.
       all_vars = Var <$> [0 .. cs_num_vars cs - 1]
       (assgn, cs') = do_simplify True env cs
    in if all_assigned all_vars assgn

--- a/tests/Test/Snarkl/DataflowSpec.hs
+++ b/tests/Test/Snarkl/DataflowSpec.hs
@@ -7,7 +7,7 @@ import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import GHC.TypeLits (KnownNat)
-import Snarkl.Common (Var)
+import Snarkl.Common (Var (Var))
 import Snarkl.Constraint.Constraints
   ( CoeffList (CoeffList),
     Constraint (..),
@@ -25,25 +25,23 @@ data SEnv a = SEnv
 -- Sample Constraints
 -- 3 + 4 * var_1 + 3 * var_2 == 0
 constraint1 :: (KnownNat p) => Constraint (Prime p)
-constraint1 = CAdd (toP 3) (CoeffList [(1, toP 4), (2, toP 3)])
+constraint1 = CAdd (toP 3) (CoeffList [(Var 1, toP 4), (Var 2, toP 3)])
 
 -- 2 * var_1 + 3 * var_2 == 4 * var_3
 constraint2 :: (KnownNat p) => Constraint (Prime p)
-constraint2 = CMult (toP 2, 1) (toP 3, 2) (toP 4, Just 3)
+constraint2 = CMult (toP 2, Var 1) (toP 3, Var 2) (toP 4, Just $ Var 3)
 
 -- NOTE: notice 4 doesn't count as a variable here, WHY?
 constraint3 :: (GaloisField k) => Constraint k
-constraint3 = CMagic 4 [2, 3] $ \vars -> do
-  let sumVars = sum vars
-  return (sumVars > 5)
+constraint3 = CMagic (Var 4) [Var 2, Var 3] $ \vars -> return True
 
 -- 4 is independent from 1,2,3
 constraint4 :: (KnownNat p) => Constraint (Prime p)
-constraint4 = CAdd (toP 3) (CoeffList [(4, toP 4), (5, toP 3)])
+constraint4 = CAdd (toP 3) (CoeffList [(Var 4, toP 4), (Var 5, toP 3)])
 
 -- 5 is independent from 1,2,3 but intersects 4
 constraint5 :: (KnownNat p) => Constraint (Prime p)
-constraint5 = CAdd (toP 3) (CoeffList [(4, toP 4), (1, toP 3)])
+constraint5 = CAdd (toP 3) (CoeffList [(Var 4, toP 4), (Var 1, toP 3)])
 
 -- Example ConstraintSystem
 exampleConstraintSystem :: ConstraintSystem (Prime P_BN128)
@@ -51,8 +49,8 @@ exampleConstraintSystem =
   ConstraintSystem
     { cs_constraints = Set.fromList [constraint1, constraint2, constraint3],
       cs_num_vars = 3,
-      cs_in_vars = [1, 2],
-      cs_out_vars = [3]
+      cs_in_vars = [Var 1, Var 2],
+      cs_out_vars = [Var 3]
     }
 
 -- Expected Result after removeUnreachable is applied

--- a/tests/Test/UnionFindSpec.hs
+++ b/tests/Test/UnionFindSpec.hs
@@ -19,26 +19,26 @@ spec = do
   describe "UnionFind Algorithm" $ do
     it "finds the root of a single element correctly" $
       property $
-        \x -> root (unite empty x x :: UnionFind Var Int) x `shouldBe` (x, unite empty x x)
+        \x -> root (unite empty (Var x) (Var x) :: UnionFind Var Int) (Var x) `shouldBe` (Var x, unite empty (Var x) (Var x))
 
     it "unifies two elements correctly" $
       property $
         forAll (arbitrary `suchThat` \(x, y) -> x < y) $ \(x, y) ->
           let uf :: UnionFind Var Int
-              uf = unite empty x y
-              rx = fst $ root uf x
-              ry = fst $ root uf y
+              uf = unite empty (Var x) (Var y)
+              rx = fst $ root uf (Var x)
+              ry = fst $ root uf (Var y)
            in rx `shouldBe` ry
 
     it "unifies 3 elements correctly" $
       property $
         forAll (arbitrary `suchThat` \(x, y, z) -> x < y && y < z) $ \(x, y, z) ->
           let uf :: UnionFind Var String
-              uf = insert z "X" (insert y "X" (insert x "X" empty))
-              uf' = unite uf x y
+              uf = insert (Var z) "X" (insert (Var y) "X" (insert (Var x) "X" empty))
+              uf' = unite uf (Var x) (Var y)
            in do
-                fst (root uf' x) `shouldBe` x
-                fst (root uf' y) `shouldBe` x
-                fst (root uf' z) `shouldBe` z
-                let uf'' = unite uf' y z
-                fst (root uf'' z) `shouldBe` x
+                fst (root uf' (Var x)) `shouldBe` Var x
+                fst (root uf' (Var y)) `shouldBe` Var x
+                fst (root uf' (Var z)) `shouldBe` Var z
+                let uf'' = unite uf' (Var y) (Var z)
+                fst (root uf'' (Var z)) `shouldBe` Var x


### PR DESCRIPTION
Use a `newtype` over the constraint `Var` type to prevent weird mixups between field elements and variables